### PR TITLE
Feature/create a popup alert view #17

### DIFF
--- a/DailyTracker_UI.xcodeproj/project.pbxproj
+++ b/DailyTracker_UI.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		51A901FE2AE3BCB800AEFEE6 /* TodayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A901FD2AE3BCB800AEFEE6 /* TodayView.swift */; };
 		51A902012AE3C2AC00AEFEE6 /* MainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A902002AE3C2AC00AEFEE6 /* MainViewModel.swift */; };
 		86023F102AE686C2004AC376 /* HapticsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86023F0F2AE686C2004AC376 /* HapticsManager.swift */; };
+		86FE6DCE2AE9558600340411 /* AlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86FE6DCD2AE9558600340411 /* AlertView.swift */; };
 		E59FBB112ADAC664002B6F16 /* UserImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E59FBB102ADAC664002B6F16 /* UserImageView.swift */; };
 /* End PBXBuildFile section */
 
@@ -55,6 +56,7 @@
 		51A901FD2AE3BCB800AEFEE6 /* TodayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayView.swift; sourceTree = "<group>"; };
 		51A902002AE3C2AC00AEFEE6 /* MainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModel.swift; sourceTree = "<group>"; };
 		86023F0F2AE686C2004AC376 /* HapticsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticsManager.swift; sourceTree = "<group>"; };
+		86FE6DCD2AE9558600340411 /* AlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertView.swift; sourceTree = "<group>"; };
 		E59FBB102ADAC664002B6F16 /* UserImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserImageView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -254,9 +256,18 @@
 		51C665DC2AE293E00072745F /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				86FE6DCC2AE9556600340411 /* Support Shapes */,
 				E59FBB102ADAC664002B6F16 /* UserImageView.swift */,
 			);
 			path = Views;
+			sourceTree = "<group>";
+		};
+		86FE6DCC2AE9556600340411 /* Support Shapes */ = {
+			isa = PBXGroup;
+			children = (
+				86FE6DCD2AE9558600340411 /* AlertView.swift */,
+			);
+			path = "Support Shapes";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -347,6 +358,7 @@
 				51A901F92AE3BC4900AEFEE6 /* FontManager.swift in Sources */,
 				51A63DF22AD1ABD700901E2B /* Persistence.swift in Sources */,
 				51A63E122AD1B58E00901E2B /* UIApplicationExtension.swift in Sources */,
+				86FE6DCE2AE9558600340411 /* AlertView.swift in Sources */,
 				51A63DEB2AD1ABD600901E2B /* MainView.swift in Sources */,
 				51A63DE92AD1ABD600901E2B /* DailyTracker_UIApp.swift in Sources */,
 			);

--- a/DailyTracker_UI/iOS/Code/Common/Extensions/ViewExtensions.swift
+++ b/DailyTracker_UI/iOS/Code/Common/Extensions/ViewExtensions.swift
@@ -16,17 +16,23 @@ extension View {
         }
     }
     
-    func alert(title: String = "", message: String = "", closeButton: CloseAlertButton = CloseAlertButton(systemName: "xmark"), dismissButton: AlertButton = AlertButton(title: "ok"), isPresented: Binding<Bool>) -> some View {
+    /// Presents  a customized alert view with a given title, message, close button, dismiss button.
+    func alert(title: String = "", message: String = "", closeButton: CloseAlertButton = CloseAlertButton(systemName: "xmark"), dismissButton: AlertButton = AlertButton(title: "OK", color: .purple), isPresented: Binding<Bool>) -> some View {
+        // Localize the title and message for internationalization.
         let title   = NSLocalizedString(title, comment: "")
         let message = NSLocalizedString(message, comment: "")
     
+        // Apply the custom alert modifier to the view.
         return modifier(CustomAlertModifier(title: title, message: message, closeButton: closeButton, dismissButton: dismissButton, isPresented: isPresented))
     }
 
+    /// Presents  a customized alert view with a given title, message, close button, primary button, secondary button.
     func alert(title: String = "", message: String = "", closeButton: CloseAlertButton = CloseAlertButton(systemName: "xmark"), primaryButton: AlertButton, secondaryButton: AlertButton, isPresented: Binding<Bool>) -> some View {
+        // Localize the title and message for internationalization.
         let title   = NSLocalizedString(title, comment: "")
         let message = NSLocalizedString(message, comment: "")
     
+        // Apply the custom alert modifier to the view.
         return modifier(CustomAlertModifier(title: title, message: message, closeButton: closeButton, primaryButton: primaryButton, secondaryButton: secondaryButton, isPresented: isPresented))
     }
 }

--- a/DailyTracker_UI/iOS/Code/Common/Extensions/ViewExtensions.swift
+++ b/DailyTracker_UI/iOS/Code/Common/Extensions/ViewExtensions.swift
@@ -15,4 +15,18 @@ extension View {
             self
         }
     }
+    
+    func alert(title: String = "", message: String = "", closeButton: CloseAlertButton = CloseAlertButton(systemName: "xmark"), dismissButton: AlertButton = AlertButton(title: "ok"), isPresented: Binding<Bool>) -> some View {
+        let title   = NSLocalizedString(title, comment: "")
+        let message = NSLocalizedString(message, comment: "")
+    
+        return modifier(CustomAlertModifier(title: title, message: message, closeButton: closeButton, dismissButton: dismissButton, isPresented: isPresented))
+    }
+
+    func alert(title: String = "", message: String = "", closeButton: CloseAlertButton = CloseAlertButton(systemName: "xmark"), primaryButton: AlertButton, secondaryButton: AlertButton, isPresented: Binding<Bool>) -> some View {
+        let title   = NSLocalizedString(title, comment: "")
+        let message = NSLocalizedString(message, comment: "")
+    
+        return modifier(CustomAlertModifier(title: title, message: message, closeButton: closeButton, primaryButton: primaryButton, secondaryButton: secondaryButton, isPresented: isPresented))
+    }
 }

--- a/DailyTracker_UI/iOS/Code/Common/Views/Support Shapes/AlertView.swift
+++ b/DailyTracker_UI/iOS/Code/Common/Views/Support Shapes/AlertView.swift
@@ -9,8 +9,7 @@ import SwiftUI
 
 struct AlertView: View {
     
-    // MARK: - Value
-    // MARK: Public
+    // MARK: - Public Properties
     let title: String
     let message: String
     let closeButton: CloseAlertButton?
@@ -18,7 +17,7 @@ struct AlertView: View {
     let primaryButton: AlertButton?
     let secondaryButton: AlertButton?
     
-    // MARK: Private
+    // MARK: Private Properties
     @State private var opacity: CGFloat           = 0
     @State private var backgroundOpacity: CGFloat = 0
     @State private var scale: CGFloat             = 0.001
@@ -26,9 +25,9 @@ struct AlertView: View {
     @Environment(\.dismiss) private var dismiss
     
     
-    // MARK: - View
-    // MARK: Public
+    // MARK: - Body
     var body: some View {
+        // Main content of the alert view.
         Color.clear
             .overlay(
                 ZStack {
@@ -46,7 +45,8 @@ struct AlertView: View {
             }
     }
     
-    // MARK: Private
+    // MARK: - Private View
+    // MARK: Alert View
     private var alertView: some View {
         VStack(spacing: 20) {
             
@@ -65,6 +65,7 @@ struct AlertView: View {
         .shadow(color: Color.black.opacity(0.4), radius: 16, x: 0, y: 12)
     }
     
+    // MARK: Title View
     @ViewBuilder
     private var titleView: some View {
         if !title.isEmpty {
@@ -77,6 +78,7 @@ struct AlertView: View {
         }
     }
     
+    // MARK: Message View
     @ViewBuilder
     private var messageView: some View {
         if !message.isEmpty {
@@ -89,6 +91,7 @@ struct AlertView: View {
         }
     }
     
+    // MARK: Buttons View
     private var buttonsView: some View {
         HStack(spacing: 12) {
             if dismissButton != nil {
@@ -102,6 +105,7 @@ struct AlertView: View {
         .padding(.top, 23)
     }
     
+    // MARK: Primary Button View
     @ViewBuilder
     private var primaryButtonView: some View {
         if let button = primaryButton {
@@ -117,6 +121,7 @@ struct AlertView: View {
         }
     }
     
+    // MARK: Secondary Button View
     @ViewBuilder
     private var secondaryButtonView: some View {
         if let button = secondaryButton {
@@ -132,6 +137,7 @@ struct AlertView: View {
         }
     }
     
+    // MARK: Dismiss Button View
     @ViewBuilder
     private var dismissButtonView: some View {
         if let button = dismissButton {
@@ -147,6 +153,7 @@ struct AlertView: View {
         }
     }
     
+    // MARK: Close Button View
     @ViewBuilder
     private var closeButtonView: some View {
         if let button = closeButton {
@@ -162,6 +169,7 @@ struct AlertView: View {
         }
     }
     
+    // MARK: Dim Background View
     private var dimView: some View {
         Color.gray
             .opacity(0.88)
@@ -174,9 +182,14 @@ struct AlertView: View {
     }
     
     
-    // MARK: - Function
-    // MARK: Private
+    // MARK: - Private Functions
+        
+        /// Animates the appearance/disappearance of the alert view.
+        /// - Parameters:
+        ///   - isShown: A boolean indicating whether the alert view should be shown or hidden.
+        ///   - completion: A closure to be executed after the animation completes.
     private func animate(isShown: Bool, completion: (() -> Void)? = nil) {
+        // Animation logic for showing/hiding the alert view
         switch isShown {
         case true:
             opacity = 1
@@ -203,17 +216,17 @@ struct AlertView: View {
     }
 }
 
+// MARK: - Alert Button
+/// Represents a button used in the custom alert view.
 struct AlertButton: View {
     
-    // MARK: - Value
-    // MARK: Public
+    // MARK: - Public Properties
     let title: LocalizedStringKey
     let color: Color
     var action: (() -> Void)? = nil
     
     
-    // MARK: - View
-    // MARK: Public
+    // MARK: - Body
     var body: some View {
         Button {
             action?()
@@ -232,16 +245,16 @@ struct AlertButton: View {
     }
 }
 
+// MARK: - Close Alert Buton
+/// Represents a close button used in the custom alert view.
 struct CloseAlertButton: View {
     
-    // MARK: - Value
-    // MARK: Public
+    // MARK: - Public Properties
     let systemName: String
     var action: (() -> Void)? = nil
     
     
-    // MARK: - View
-    // MARK: Public
+    // MARK: - Body
     var body: some View {
         Button {
             action?()
@@ -254,14 +267,14 @@ struct CloseAlertButton: View {
     }
 }
 
+// MARK: - Custom Alert Modifier
+/// A view modifier for presenting the custom alert view as a full-screen cover.
 struct CustomAlertModifier {
     
-    // MARK: - Value
-    // MARK: Private
+    // MARK: - Private Properties
     @Binding private var isPresented: Bool
     @State private var internalIsPresented = true
     
-    // MARK: Private
     private let title: String
     private let message: String
     private let closeButton: CloseAlertButton?
@@ -270,10 +283,10 @@ struct CustomAlertModifier {
     private let secondaryButton: AlertButton?
 }
 
-
 extension CustomAlertModifier: ViewModifier {
     @ViewBuilder
     func body(content: Content) -> some View {
+        // Applies the alert view as a full-screen cover with the specified properties.
         content
             .fullScreenCover(isPresented: $isPresented) {
                 ZStack{
@@ -288,9 +301,9 @@ extension CustomAlertModifier: ViewModifier {
     
 }
 
-
 extension CustomAlertModifier {
     
+    /// Initializes the modifier with a close button and a dismiss button.
     init(title: String = "", message: String = "", closeButton: CloseAlertButton, dismissButton: AlertButton, isPresented: Binding<Bool>) {
         self.title         = title
         self.message       = message
@@ -303,6 +316,7 @@ extension CustomAlertModifier {
         _isPresented = isPresented
     }
     
+    /// Initializes the modifier with a close button, a primary button, and a secondary button.
     init(title: String = "", message: String = "", closeButton: CloseAlertButton, primaryButton: AlertButton, secondaryButton: AlertButton, isPresented: Binding<Bool>) {
         self.title           = title
         self.message         = message

--- a/DailyTracker_UI/iOS/Code/Common/Views/Support Shapes/AlertView.swift
+++ b/DailyTracker_UI/iOS/Code/Common/Views/Support Shapes/AlertView.swift
@@ -30,15 +30,15 @@ struct AlertView: View {
     // MARK: Public
     var body: some View {
         Color.clear
-            .overlay(        ZStack {
-                dimView
-                    .onTapGesture { dismiss() }
-                alertView
-                    .scaleEffect(scale)
-                    .opacity(opacity)
-            }
-                .transition(.opacity)
-                             
+            .overlay(
+                ZStack {
+                    dimView
+                    alertView
+                        .scaleEffect(scale)
+                        .opacity(opacity)
+                }
+                    .transition(.opacity)
+                
             )
             .ignoresSafeArea()
             .task {
@@ -69,7 +69,7 @@ struct AlertView: View {
     private var titleView: some View {
         if !title.isEmpty {
             Text(title)
-                .font(.system(size: 18, weight: .bold))
+                .font(Font.custom("Degular-Bold", size: 18))
                 .foregroundColor(.black)
                 .lineSpacing(24 - UIFont.systemFont(ofSize: 18, weight: .bold).lineHeight)
                 .multilineTextAlignment(.leading)
@@ -81,7 +81,7 @@ struct AlertView: View {
     private var messageView: some View {
         if !message.isEmpty {
             Text(message)
-                .font(.system(size: title.isEmpty ? 18 : 16))
+                .font(Font.custom("Degular-Regular", size: title.isEmpty ? 18 : 16))
                 .foregroundColor(title.isEmpty ? .black : .gray)
                 .lineSpacing(24 - UIFont.systemFont(ofSize: title.isEmpty ? 18 : 16).lineHeight)
                 .multilineTextAlignment(.leading)
@@ -105,7 +105,7 @@ struct AlertView: View {
     @ViewBuilder
     private var primaryButtonView: some View {
         if let button = primaryButton {
-            AlertButton(title: button.title) {
+            AlertButton(title: button.title, color: button.color) {
                 animate(isShown: false) {
                     dismiss()
                 }
@@ -120,7 +120,7 @@ struct AlertView: View {
     @ViewBuilder
     private var secondaryButtonView: some View {
         if let button = secondaryButton {
-            AlertButton(title: button.title) {
+            AlertButton(title: button.title, color: button.color) {
                 animate(isShown: false) {
                     dismiss()
                 }
@@ -135,7 +135,7 @@ struct AlertView: View {
     @ViewBuilder
     private var dismissButtonView: some View {
         if let button = dismissButton {
-            AlertButton(title: button.title) {
+            AlertButton(title: button.title , color: button.color) {
                 animate(isShown: false) {
                     dismiss()
                 }
@@ -166,6 +166,11 @@ struct AlertView: View {
         Color.gray
             .opacity(0.88)
             .opacity(backgroundOpacity)
+            .onTapGesture {
+                animate(isShown: false) {
+                    dismiss()
+                }
+            }
     }
     
     
@@ -203,6 +208,7 @@ struct AlertButton: View {
     // MARK: - Value
     // MARK: Public
     let title: LocalizedStringKey
+    let color: Color
     var action: (() -> Void)? = nil
     
     
@@ -218,9 +224,11 @@ struct AlertButton: View {
                 .foregroundColor(.white)
                 .padding(.horizontal, 20)
         }
-        .frame(height: 30)
-        .background(Color.purple)
-        .cornerRadius(10)
+        .frame(minWidth: 0, maxWidth: .infinity, alignment: .center)
+        .frame(height: 44)
+        .background(color)
+        .cornerRadius(8)
+        
     }
 }
 
@@ -240,8 +248,6 @@ struct CloseAlertButton: View {
             
         } label: {
             Image(systemName: systemName)
-            //                .font(.system(.title, design: .rounded))
-            //                .symbolRenderingMode(.palette)
                 .foregroundStyle(.gray, .gray.opacity(0.2))
         }
         .frame(height: 10)
@@ -314,9 +320,9 @@ extension CustomAlertModifier {
 struct AlertView_Previews: PreviewProvider {
     
     static var previews: some View {
-        let dismissButton   = AlertButton(title: "OK")
-        let primaryButton   = AlertButton(title: "Got it")
-        let secondaryButton = AlertButton(title: "Cancel")
+        let dismissButton   = AlertButton(title: "OK", color: .green)
+        let primaryButton   = AlertButton(title: "Got it", color: .purple)
+        let secondaryButton = AlertButton(title: "Cancel", color: .red)
         let closeButton = CloseAlertButton(systemName: "xmark")
         
         let title = "This is your life. Do what you want and do it often."

--- a/DailyTracker_UI/iOS/Code/Common/Views/Support Shapes/AlertView.swift
+++ b/DailyTracker_UI/iOS/Code/Common/Views/Support Shapes/AlertView.swift
@@ -7,33 +7,8 @@
 
 import SwiftUI
 
-struct DemoView: View {
-
-    // MARK: - Value
-    // MARK: Private
-    @State private var isAlertPresented = false
-
-
-    // MARK: - View
-    // MARK: Public
-    var body: some View {
-        ZStack {
-            Button {
-                isAlertPresented = true
-
-            } label: {
-                Text("Alert test")
-            }
-        }
-        .alert(title: "title", message: "message",
-           primaryButton: AlertButton(title: "Yes", action: { }),
-           secondaryButton: AlertButton(title: "No", action: {  }),
-           isPresented: $isAlertPresented)
-    }
-}
-
 struct AlertView: View {
-
+    
     // MARK: - Value
     // MARK: Public
     let title: String
@@ -47,31 +22,34 @@ struct AlertView: View {
     @State private var opacity: CGFloat           = 0
     @State private var backgroundOpacity: CGFloat = 0
     @State private var scale: CGFloat             = 0.001
-
+    
     @Environment(\.dismiss) private var dismiss
-
-
+    
+    
     // MARK: - View
     // MARK: Public
     var body: some View {
-
-        ZStack {
-            dimView
-            alertView
-                .scaleEffect(scale)
-                .opacity(opacity)
-        }
-        .ignoresSafeArea()
-        .transition(.opacity)
-        .task {
-            animate(isShown: true)
-        }
+        Color.clear
+            .overlay(        ZStack {
+                dimView
+                    .onTapGesture { dismiss() }
+                alertView
+                    .scaleEffect(scale)
+                    .opacity(opacity)
+            }
+                .transition(.opacity)
+                             
+            )
+            .ignoresSafeArea()
+            .task {
+                animate(isShown: true)
+            }
     }
-
+    
     // MARK: Private
     private var alertView: some View {
         VStack(spacing: 20) {
-
+            
             HStack(alignment: .top, content: {
                 Spacer()
                 closeButtonView
@@ -86,7 +64,7 @@ struct AlertView: View {
         .cornerRadius(12)
         .shadow(color: Color.black.opacity(0.4), radius: 16, x: 0, y: 12)
     }
-
+    
     @ViewBuilder
     private var titleView: some View {
         if !title.isEmpty {
@@ -98,7 +76,7 @@ struct AlertView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
-
+    
     @ViewBuilder
     private var messageView: some View {
         if !message.isEmpty {
@@ -110,12 +88,12 @@ struct AlertView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
-
+    
     private var buttonsView: some View {
         HStack(spacing: 12) {
             if dismissButton != nil {
                 dismissButtonView
-    
+                
             } else if primaryButton != nil, secondaryButton != nil {
                 secondaryButtonView
                 primaryButtonView
@@ -123,7 +101,7 @@ struct AlertView: View {
         }
         .padding(.top, 23)
     }
-
+    
     @ViewBuilder
     private var primaryButtonView: some View {
         if let button = primaryButton {
@@ -131,14 +109,14 @@ struct AlertView: View {
                 animate(isShown: false) {
                     dismiss()
                 }
-            
+                
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
                     button.action?()
                 }
             }
         }
     }
-
+    
     @ViewBuilder
     private var secondaryButtonView: some View {
         if let button = secondaryButton {
@@ -146,14 +124,14 @@ struct AlertView: View {
                 animate(isShown: false) {
                     dismiss()
                 }
-        
+                
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
                     button.action?()
                 }
             }
         }
     }
-
+    
     @ViewBuilder
     private var dismissButtonView: some View {
         if let button = dismissButton {
@@ -161,7 +139,7 @@ struct AlertView: View {
                 animate(isShown: false) {
                     dismiss()
                 }
-        
+                
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
                     button.action?()
                 }
@@ -176,43 +154,43 @@ struct AlertView: View {
                 animate(isShown: false) {
                     dismiss()
                 }
-        
+                
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
                     button.action?()
                 }
             }
         }
     }
-
+    
     private var dimView: some View {
         Color.gray
             .opacity(0.88)
             .opacity(backgroundOpacity)
     }
-
-
+    
+    
     // MARK: - Function
     // MARK: Private
     private func animate(isShown: Bool, completion: (() -> Void)? = nil) {
         switch isShown {
         case true:
             opacity = 1
-    
+            
             withAnimation(.spring(response: 0.3, dampingFraction: 0.9, blendDuration: 0).delay(0.4)) {
                 backgroundOpacity = 0.5
                 scale             = 1
             }
-    
+            
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
                 completion?()
             }
-    
+            
         case false:
             withAnimation(.easeOut(duration: 0.2)) {
                 backgroundOpacity = 0
                 opacity           = 0
             }
-    
+            
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
                 completion?()
             }
@@ -221,7 +199,7 @@ struct AlertView: View {
 }
 
 struct AlertButton: View {
-
+    
     // MARK: - Value
     // MARK: Public
     let title: LocalizedStringKey
@@ -232,8 +210,8 @@ struct AlertButton: View {
     // MARK: Public
     var body: some View {
         Button {
-          action?()
-        
+            action?()
+            
         } label: {
             Text(title)
                 .font(.system(size: 14, weight: .medium))
@@ -247,7 +225,7 @@ struct AlertButton: View {
 }
 
 struct CloseAlertButton: View {
-
+    
     // MARK: - Value
     // MARK: Public
     let systemName: String
@@ -258,12 +236,12 @@ struct CloseAlertButton: View {
     // MARK: Public
     var body: some View {
         Button {
-          action?()
-        
+            action?()
+            
         } label: {
             Image(systemName: systemName)
-//                .font(.system(.title, design: .rounded))
-//                .symbolRenderingMode(.palette)
+            //                .font(.system(.title, design: .rounded))
+            //                .symbolRenderingMode(.palette)
                 .foregroundStyle(.gray, .gray.opacity(0.2))
         }
         .frame(height: 10)
@@ -271,11 +249,12 @@ struct CloseAlertButton: View {
 }
 
 struct CustomAlertModifier {
-
+    
     // MARK: - Value
     // MARK: Private
     @Binding private var isPresented: Bool
-
+    @State private var internalIsPresented = true
+    
     // MARK: Private
     private let title: String
     private let message: String
@@ -287,58 +266,66 @@ struct CustomAlertModifier {
 
 
 extension CustomAlertModifier: ViewModifier {
-
+    @ViewBuilder
     func body(content: Content) -> some View {
         content
             .fullScreenCover(isPresented: $isPresented) {
-                AlertView(title: title, message: message, closeButton: closeButton, dismissButton: dismissButton, primaryButton: primaryButton, secondaryButton: secondaryButton)
+                ZStack{
+                    AlertView(title: title, message: message, closeButton: closeButton, dismissButton: dismissButton, primaryButton: primaryButton, secondaryButton: secondaryButton)
+                }
+                .presentationBackground(.clear)
+                
             }
+        
     }
+    
+    
 }
 
-extension CustomAlertModifier {
 
+extension CustomAlertModifier {
+    
     init(title: String = "", message: String = "", closeButton: CloseAlertButton, dismissButton: AlertButton, isPresented: Binding<Bool>) {
         self.title         = title
         self.message       = message
         self.closeButton   = closeButton
         self.dismissButton = dismissButton
-    
+        
         self.primaryButton   = nil
         self.secondaryButton = nil
-    
+        
         _isPresented = isPresented
     }
-
+    
     init(title: String = "", message: String = "", closeButton: CloseAlertButton, primaryButton: AlertButton, secondaryButton: AlertButton, isPresented: Binding<Bool>) {
         self.title           = title
         self.message         = message
         self.closeButton     = closeButton
         self.primaryButton   = primaryButton
         self.secondaryButton = secondaryButton
-    
+        
         self.dismissButton = nil
-    
+        
         _isPresented = isPresented
     }
 }
 
 #if DEBUG
 struct AlertView_Previews: PreviewProvider {
-
+    
     static var previews: some View {
         let dismissButton   = AlertButton(title: "OK")
         let primaryButton   = AlertButton(title: "Got it")
         let secondaryButton = AlertButton(title: "Cancel")
         let closeButton = CloseAlertButton(systemName: "xmark")
-
+        
         let title = "This is your life. Do what you want and do it often."
         let message = """
                     If you don't like something, change it.
                     If you don't like your job, quit.
                     If you don't have enough time, stop watching TV.
                     """
-
+        
         return VStack {
             AlertView(title: title, message: message, closeButton: closeButton, dismissButton: nil,           primaryButton: nil,           secondaryButton: nil)
             AlertView(title: title, message: message, closeButton: closeButton, dismissButton: dismissButton, primaryButton: nil,           secondaryButton: nil)
@@ -349,7 +336,3 @@ struct AlertView_Previews: PreviewProvider {
     }
 }
 #endif
-
-//#Preview(body: {
-//    DemoView()
-//})

--- a/DailyTracker_UI/iOS/Code/Common/Views/Support Shapes/AlertView.swift
+++ b/DailyTracker_UI/iOS/Code/Common/Views/Support Shapes/AlertView.swift
@@ -1,0 +1,355 @@
+//
+//  AlertView.swift
+//  DailyTracker_UI
+//
+//  Created by Mark Golubev on 25/10/2023.
+//
+
+import SwiftUI
+
+struct DemoView: View {
+
+    // MARK: - Value
+    // MARK: Private
+    @State private var isAlertPresented = false
+
+
+    // MARK: - View
+    // MARK: Public
+    var body: some View {
+        ZStack {
+            Button {
+                isAlertPresented = true
+
+            } label: {
+                Text("Alert test")
+            }
+        }
+        .alert(title: "title", message: "message",
+           primaryButton: AlertButton(title: "Yes", action: { }),
+           secondaryButton: AlertButton(title: "No", action: {  }),
+           isPresented: $isAlertPresented)
+    }
+}
+
+struct AlertView: View {
+
+    // MARK: - Value
+    // MARK: Public
+    let title: String
+    let message: String
+    let closeButton: CloseAlertButton?
+    let dismissButton: AlertButton?
+    let primaryButton: AlertButton?
+    let secondaryButton: AlertButton?
+    
+    // MARK: Private
+    @State private var opacity: CGFloat           = 0
+    @State private var backgroundOpacity: CGFloat = 0
+    @State private var scale: CGFloat             = 0.001
+
+    @Environment(\.dismiss) private var dismiss
+
+
+    // MARK: - View
+    // MARK: Public
+    var body: some View {
+
+        ZStack {
+            dimView
+            alertView
+                .scaleEffect(scale)
+                .opacity(opacity)
+        }
+        .ignoresSafeArea()
+        .transition(.opacity)
+        .task {
+            animate(isShown: true)
+        }
+    }
+
+    // MARK: Private
+    private var alertView: some View {
+        VStack(spacing: 20) {
+
+            HStack(alignment: .top, content: {
+                Spacer()
+                closeButtonView
+            })
+            titleView
+            messageView
+            buttonsView
+        }
+        .padding(24)
+        .frame(width: 320)
+        .background(.white)
+        .cornerRadius(12)
+        .shadow(color: Color.black.opacity(0.4), radius: 16, x: 0, y: 12)
+    }
+
+    @ViewBuilder
+    private var titleView: some View {
+        if !title.isEmpty {
+            Text(title)
+                .font(.system(size: 18, weight: .bold))
+                .foregroundColor(.black)
+                .lineSpacing(24 - UIFont.systemFont(ofSize: 18, weight: .bold).lineHeight)
+                .multilineTextAlignment(.leading)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    @ViewBuilder
+    private var messageView: some View {
+        if !message.isEmpty {
+            Text(message)
+                .font(.system(size: title.isEmpty ? 18 : 16))
+                .foregroundColor(title.isEmpty ? .black : .gray)
+                .lineSpacing(24 - UIFont.systemFont(ofSize: title.isEmpty ? 18 : 16).lineHeight)
+                .multilineTextAlignment(.leading)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var buttonsView: some View {
+        HStack(spacing: 12) {
+            if dismissButton != nil {
+                dismissButtonView
+    
+            } else if primaryButton != nil, secondaryButton != nil {
+                secondaryButtonView
+                primaryButtonView
+            }
+        }
+        .padding(.top, 23)
+    }
+
+    @ViewBuilder
+    private var primaryButtonView: some View {
+        if let button = primaryButton {
+            AlertButton(title: button.title) {
+                animate(isShown: false) {
+                    dismiss()
+                }
+            
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+                    button.action?()
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var secondaryButtonView: some View {
+        if let button = secondaryButton {
+            AlertButton(title: button.title) {
+                animate(isShown: false) {
+                    dismiss()
+                }
+        
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+                    button.action?()
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var dismissButtonView: some View {
+        if let button = dismissButton {
+            AlertButton(title: button.title) {
+                animate(isShown: false) {
+                    dismiss()
+                }
+        
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+                    button.action?()
+                }
+            }
+        }
+    }
+    
+    @ViewBuilder
+    private var closeButtonView: some View {
+        if let button = closeButton {
+            CloseAlertButton(systemName: button.systemName) {
+                animate(isShown: false) {
+                    dismiss()
+                }
+        
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+                    button.action?()
+                }
+            }
+        }
+    }
+
+    private var dimView: some View {
+        Color.gray
+            .opacity(0.88)
+            .opacity(backgroundOpacity)
+    }
+
+
+    // MARK: - Function
+    // MARK: Private
+    private func animate(isShown: Bool, completion: (() -> Void)? = nil) {
+        switch isShown {
+        case true:
+            opacity = 1
+    
+            withAnimation(.spring(response: 0.3, dampingFraction: 0.9, blendDuration: 0).delay(0.4)) {
+                backgroundOpacity = 0.5
+                scale             = 1
+            }
+    
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                completion?()
+            }
+    
+        case false:
+            withAnimation(.easeOut(duration: 0.2)) {
+                backgroundOpacity = 0
+                opacity           = 0
+            }
+    
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                completion?()
+            }
+        }
+    }
+}
+
+struct AlertButton: View {
+
+    // MARK: - Value
+    // MARK: Public
+    let title: LocalizedStringKey
+    var action: (() -> Void)? = nil
+    
+    
+    // MARK: - View
+    // MARK: Public
+    var body: some View {
+        Button {
+          action?()
+        
+        } label: {
+            Text(title)
+                .font(.system(size: 14, weight: .medium))
+                .foregroundColor(.white)
+                .padding(.horizontal, 20)
+        }
+        .frame(height: 30)
+        .background(Color.purple)
+        .cornerRadius(10)
+    }
+}
+
+struct CloseAlertButton: View {
+
+    // MARK: - Value
+    // MARK: Public
+    let systemName: String
+    var action: (() -> Void)? = nil
+    
+    
+    // MARK: - View
+    // MARK: Public
+    var body: some View {
+        Button {
+          action?()
+        
+        } label: {
+            Image(systemName: systemName)
+//                .font(.system(.title, design: .rounded))
+//                .symbolRenderingMode(.palette)
+                .foregroundStyle(.gray, .gray.opacity(0.2))
+        }
+        .frame(height: 10)
+    }
+}
+
+struct CustomAlertModifier {
+
+    // MARK: - Value
+    // MARK: Private
+    @Binding private var isPresented: Bool
+
+    // MARK: Private
+    private let title: String
+    private let message: String
+    private let closeButton: CloseAlertButton?
+    private let dismissButton: AlertButton?
+    private let primaryButton: AlertButton?
+    private let secondaryButton: AlertButton?
+}
+
+
+extension CustomAlertModifier: ViewModifier {
+
+    func body(content: Content) -> some View {
+        content
+            .fullScreenCover(isPresented: $isPresented) {
+                AlertView(title: title, message: message, closeButton: closeButton, dismissButton: dismissButton, primaryButton: primaryButton, secondaryButton: secondaryButton)
+            }
+    }
+}
+
+extension CustomAlertModifier {
+
+    init(title: String = "", message: String = "", closeButton: CloseAlertButton, dismissButton: AlertButton, isPresented: Binding<Bool>) {
+        self.title         = title
+        self.message       = message
+        self.closeButton   = closeButton
+        self.dismissButton = dismissButton
+    
+        self.primaryButton   = nil
+        self.secondaryButton = nil
+    
+        _isPresented = isPresented
+    }
+
+    init(title: String = "", message: String = "", closeButton: CloseAlertButton, primaryButton: AlertButton, secondaryButton: AlertButton, isPresented: Binding<Bool>) {
+        self.title           = title
+        self.message         = message
+        self.closeButton     = closeButton
+        self.primaryButton   = primaryButton
+        self.secondaryButton = secondaryButton
+    
+        self.dismissButton = nil
+    
+        _isPresented = isPresented
+    }
+}
+
+#if DEBUG
+struct AlertView_Previews: PreviewProvider {
+
+    static var previews: some View {
+        let dismissButton   = AlertButton(title: "OK")
+        let primaryButton   = AlertButton(title: "Got it")
+        let secondaryButton = AlertButton(title: "Cancel")
+        let closeButton = CloseAlertButton(systemName: "xmark")
+
+        let title = "This is your life. Do what you want and do it often."
+        let message = """
+                    If you don't like something, change it.
+                    If you don't like your job, quit.
+                    If you don't have enough time, stop watching TV.
+                    """
+
+        return VStack {
+            AlertView(title: title, message: message, closeButton: closeButton, dismissButton: nil,           primaryButton: nil,           secondaryButton: nil)
+            AlertView(title: title, message: message, closeButton: closeButton, dismissButton: dismissButton, primaryButton: nil,           secondaryButton: nil)
+            AlertView(title: title, message: message, closeButton: closeButton, dismissButton: nil,           primaryButton: primaryButton, secondaryButton: secondaryButton)
+        }
+        .previewDevice("iPhone 13 Pro Max")
+        .preferredColorScheme(.light)
+    }
+}
+#endif
+
+//#Preview(body: {
+//    DemoView()
+//})


### PR DESCRIPTION
#17 

**Add**

- An Injectable Alert Popup View.
- Make it as a Generic View, that can be shown on top of any Parent View
- Add variables to add the title, description, and the action button.

How to use:

Just use the .alert modifier
<img width="661" alt="Screenshot 2023-10-28 at 12 01 52" src="https://github.com/Shubham0812/DailyTracker_UI/assets/78806623/7247aab5-b84c-4ccd-be68-3dc7bd5e3001">
You can use 3 types of Popups. 

1. Without Buttons (but you can add action to X button)
2. With Dismiss Button - just one button (u can customise it setting up title, colour, action)
3. With two buttons (u can customise it setting up title, colour, action)
<img width="383" alt="Screenshot 2023-10-28 at 11 51 56" src="https://github.com/Shubham0812/DailyTracker_UI/assets/78806623/37eeead5-d1d3-46c6-8b84-20cb2f9bb2af">

This is in app example:
![Simulator Screenshot - iPhone 15 Pro - 2023-10-28 at 11 52 37](https://github.com/Shubham0812/DailyTracker_UI/assets/78806623/dad9c43e-2ecf-4da9-a82b-8cb2b9602e9a)

